### PR TITLE
fix: allow patch version in go.mod

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,3 +14,12 @@ jobs:
         run: |
           test "${{ steps.selftest.outputs.go_version }}" == "1.22.0"
           test "${{ steps.selftest.outputs.go_module }}" == "github.com/pawndev/go-modfile-information"
+      - name: Self test two digits format
+        id: selftest_two_digits
+        uses: ./
+        with:
+          modfile: tests/two-digits.go.mod
+      - name: Check outputs
+        run: |
+          test "${{ steps.selftest_two_digits.outputs.go_version }}" == "1.21"
+          test "${{ steps.selftest_two_digits.outputs.go_module }}" == "github.com/pawndev/go-modfile-information"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,5 +12,5 @@ jobs:
           modfile: go.mod
       - name: Check outputs
         run: |
-          test "${{ steps.selftest.outputs.go_version }}" == "1.20"
+          test "${{ steps.selftest.outputs.go_version }}" == "1.22.0"
           test "${{ steps.selftest.outputs.go_module }}" == "github.com/pawndev/go-modfile-information"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ See the [examples](#examples) for how to use it
 
 ### Inputs
 
-| Input                       | Description                     | Default value |
-|-----------------------------|---------------------------------|---------------|
-| `modfile`                   | An example mandatory input      | go.mod        |
+| Input     | Description                | Default value |
+| --------- | -------------------------- | ------------- |
+| `modfile` | An example mandatory input | go.mod        |
 
 ### Outputs
 
 | Output       | Description              |
-|--------------|--------------------------|
+| ------------ | ------------------------ |
 | `go_version` | Go version of the module |
 | `go_module`  | Go module name           |
 
@@ -51,3 +51,5 @@ with:
 
 Be sure to have [act](https://github.com/nektos/act) locally and available il your `$PATH`.
 And then you can `make test` to launch the project locally.
+
+Folder `tests` contains another go.mod file with old version format using only major and minor without the patch number `1.21`.

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/pawndev/go-modfile-information
 
-go 1.20
+go 1.22.0
+
+toolchain go1.23.0
 
 require (
-	github.com/sethvargo/go-githubactions v1.1.0
-	golang.org/x/mod v0.9.0
+	github.com/sethvargo/go-githubactions v1.3.0
+	golang.org/x/mod v0.21.0
 )
-
-require github.com/sethvargo/go-envconfig v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,4 @@
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/sethvargo/go-envconfig v0.8.0 h1:AcmdAewSFAc7pQ1Ghz+vhZkilUtxX559QlDuLLiSkdI=
-github.com/sethvargo/go-envconfig v0.8.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
-github.com/sethvargo/go-githubactions v1.1.0 h1:mg03w+b+/s5SMS298/2G6tHv8P0w0VhUFaqL1THIqzY=
-github.com/sethvargo/go-githubactions v1.1.0/go.mod h1:qIboSF7yq2Qnaw2WXDsqCReM0Lo1gU4QXUWmhBC3pxE=
-golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
-golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+github.com/sethvargo/go-githubactions v1.3.0 h1:Kg633LIUV2IrJsqy2MfveiED/Ouo+H2P0itWS0eLh8A=
+github.com/sethvargo/go-githubactions v1.3.0/go.mod h1:7/4WeHgYfSz9U5vwuToCK9KPnELVHAhGtRwLREOQV80=
+golang.org/x/mod v0.21.0 h1:vvrHzRwRfVKSiLrG+d4FMl/Qi4ukBCE6kZlTUkDYRT0=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=

--- a/tests/two-digits.go.mod
+++ b/tests/two-digits.go.mod
@@ -1,0 +1,8 @@
+module github.com/pawndev/go-modfile-information
+
+go 1.21
+
+require (
+	github.com/sethvargo/go-githubactions v1.3.0
+	golang.org/x/mod v0.21.0
+)


### PR DESCRIPTION
Update dependencies not to fail with new go.mod file containing patch version